### PR TITLE
[Mozilla Branding Removal] Changes Mozilla ops identifiers to Hubs Foundation

### DIFF
--- a/.github/workflows/nearspark.yml
+++ b/.github/workflows/nearspark.yml
@@ -7,9 +7,9 @@ on:
 
 jobs:
   turkeyGitops:
-    uses: mozilla/hubs-ops/.github/workflows/turkeyGitops.yml@master
+    uses: Hubs-Foundation/hubs-ops/.github/workflows/turkeyGitops.yml@master
     with:
-      registry: mozillareality
+      registry: hubsfoundation
       # dockerfile: Dockerfile
     secrets:
       DOCKER_HUB_PWD: ${{ secrets.DOCKER_HUB_PWD }}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-AWS Lambda function for generating image thumbnails.
+Express.js service for creating image thumbnails (originally an AWS lambda)

--- a/polycosm-publish.sh
+++ b/polycosm-publish.sh
@@ -12,7 +12,7 @@ fi
 if [[ -z "$HUBS_OPS_PATH" ]]; then
   echo -e "To use this deploy script, you need to clone out the hubs-ops repo
 
-git clone git@github.com:mozilla/hubs-ops.git
+git clone git@github.com:Hubs-Foundation/hubs-ops.git
 
 Then set HUBS_OPS_PATH to point to the cloned repo."
   exit 1

--- a/run-serverless.sh
+++ b/run-serverless.sh
@@ -14,7 +14,7 @@ fi
 if [[ -z "$HUBS_OPS_PATH" ]]; then
   echo -e "To use this deploy script, you need to clone out the hubs-ops repo
 
-git clone git@github.com:mozilla/hubs-ops.git
+git clone git@github.com:Hubs-Foundation/hubs-ops.git
 
 Then set HUBS_OPS_PATH to point to the cloned repo."
   exit 1

--- a/template.yaml
+++ b/template.yaml
@@ -7,12 +7,12 @@ Metadata:
   AWS::ServerlessRepo::Application:
     Name: nearspark
     Description: Image resizing services for Hubs Cloud
-    Author: Mozilla
+    Author: Hubs Foundation
     SpdxLicenseId: MPL-2.0
     LicenseUrl: LICENSE
     ReadmeUrl: README.md
     SemanticVersion: 0.1.0
-    SourceCodeUrl: https://github.com/mozilla/nearspark
+    SourceCodeUrl: https://github.com/Hubs-Foundation/nearspark
 
 Parameters:
   NearsparkRoleArn:

--- a/template.yaml
+++ b/template.yaml
@@ -7,7 +7,7 @@ Metadata:
   AWS::ServerlessRepo::Application:
     Name: nearspark
     Description: Image resizing services for Hubs Cloud
-    Author: Hubs Foundation
+    Author: 'Mozilla (Original Author), Hubs Foundation (Current Maintainer)'
     SpdxLicenseId: MPL-2.0
     LicenseUrl: LICENSE
     ReadmeUrl: README.md


### PR DESCRIPTION
## What?
Changes Mozilla ops identifiers to Hubs Foundation


## Why?
to allow future updates, and remove Mozilla branding

## How to test
1. Install the image `dougreeder/nearspark:mozilla-branding-removal-2026-01-21-01-39` in a Hubs instance.
2. Follow the nearspark logs with `kubectl logs -l app=nearspark -f -n hcce`
3. Open the Sketchfab browser; observe that a thumbnail image is created for each model, and there are no errors in the nearspark logs

## Documentation of functionality
No change in user functionality. 
Image now available under hubsfoundation in Docker Hub

## Open questions
Which of the ops files can be deleted?

## Additional details or related context
removes Mozilla branding

